### PR TITLE
:feat: Adicionar configuração de ambiente para DEBUG e CSRF Trusted O…

### DIFF
--- a/project_twitter/settings.py
+++ b/project_twitter/settings.py
@@ -16,7 +16,7 @@ DEBUG = os.getenv('DEBUG', 'False') == 'True'
 ALLOWED_HOSTS = ['127.0.0.1', 'localhost', 'twitter-clone-api.herokuapp.com', '.herokuapp.com']  # Lista de hosts permitidos
 
 # Lista de origens confiáveis para CSRF
-CSRF_TRUSTED_ORIGINS = ['https://twitter-clone-api.herokuapp.com', 'https://twitter-clone-api-6ddd12cb8d81.herokuapp.com']
+CSRF_TRUSTED_ORIGINS = ['https://twitter-clone-api.herokuapp.com', 'https://twitter-clone-api-42ae09139a6e.herokuapp.com']
 
 # Aplicações instaladas
 INSTALLED_APPS = [


### PR DESCRIPTION
Este pull request adiciona uma nova configuração ao arquivo `settings.py` para que a variável `DEBUG` seja configurada com base na variável de ambiente. Também foram feitas atualizações para incluir a URL do Heroku na lista de origens confiáveis para a verificação de CSRF (`CSRF_TRUSTED_ORIGINS`).

## Alterações Realizadas

- Adição da configuração para `DEBUG` baseada na variável de ambiente (`os.getenv('DEBUG', 'False') == 'True'`).
- Inclusão da URL do Heroku no `ALLOWED_HOSTS` e `CSRF_TRUSTED_ORIGINS` para garantir que a aplicação possa realizar POST requests com proteção de CSRF no Heroku.
- Atualização das dependências de segurança e configuração do ambiente de produção.